### PR TITLE
goのパッケージをアーキテクチャに合わせて取得するようにした

### DIFF
--- a/isucoutea/docker-compose.go.yml
+++ b/isucoutea/docker-compose.go.yml
@@ -3,6 +3,5 @@ services:
   app:
     build:
       context: ./webapp/go
-    platform: linux/x86_64
     environment:
       ISUCOUTEA_RUN_TYPE: "${ISUCOUTEA_RUN_TYPE-run_go}"

--- a/isucoutea/webapp/go/Dockerfile
+++ b/isucoutea/webapp/go/Dockerfile
@@ -32,7 +32,8 @@ ENV PATH="$GOROOT/bin:$PATH"
 ENV GOPATH="$HOME/.local/go"
 
 RUN GO_VERSION="1.18.5" && \
-    wget -O go.tgz "https://go.dev/dl/go$GO_VERSION.linux-amd64.tar.gz" && \
+    arch="$(dpkg --print-architecture)" && arch="${arch##*-}" && \
+    wget -O go.tgz "https://go.dev/dl/go$GO_VERSION.linux-${arch}.tar.gz" && \
     sudo tar -C /usr/local -xzf go.tgz && \
     rm -f go.tgz && \
     echo "installed version: $(go version)"


### PR DESCRIPTION
## 変更概要
- goのパッケージをプラットフォームに合わせて取得するようにした
    - プラットフォームの判定は[docker公式イメージのロジックを参考](https://github.com/docker-library/golang/blob/8d0fa6028120904e16fe761f095bd0620b68eab2/1.18/bullseye/Dockerfile)にした。
    - goのパッケージを `linux-amd64` 固定でしてたらそりゃM1で動かないよね。

- プラットフォームの固定は不要なので削除
    - #15 で`platform: linux/x86_64` で固定して回避していたが不要となった。

## その他 お気持ち
- 取り急ぎの対応なのでミニマム。
- 既存環境に影響を与えたくなかったので、ルートにあるDockerfileはプラットフォームの判定してません。
    - あくまでM1でgo使いたい場合はdocker-composeを上書きしてねというスタンスはそのまま。READMEの通り。
    - 今後言語ごとにDockerfileを分けたいという気持ちもある。

## 動作確認
- M1 mac にてgoのベンチマーク通ることを確認。

## 謝辞
こたすけさん情報提供ありがとうございました
https://twitter.com/kotasukesanta/status/1559483474238615552